### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "java10"
+  run = "java Main.java"
+  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Haven
 Small Group Project for Sacramento State GDDC
 Admins are Jaime Ramirez, Armando Juarez, Nathan Aquino, Carlos Caceres
+[![Run on Repl.it](https://repl.it/badge/github/MasterBlaz3/Haven)](https://repl.it/github/MasterBlaz3/Haven)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).